### PR TITLE
adding missing namespace

### DIFF
--- a/kubernetes/namespace.yml
+++ b/kubernetes/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx


### PR DESCRIPTION
Without this file, the cluster fails with:
```
/docker-dns$ kubectl apply -f kubernetes/
deployment.apps/dns-deployment configured
deployment.apps/dns-deployment configured
configmap/tcp-services unchanged
configmap/udp-services unchanged
service/nginx-nginx-ingress-controller unchanged
secret/dns-pem configured
secret/dns-key configured
service/dns configured
service/dns configured
Error from server (NotFound): error when creating "kubernetes/nginx-configmap.yml": namespaces "ingress-nginx" not found
Error from server (NotFound): error when creating "kubernetes/nginx-configmap.yml": namespaces "ingress-nginx" not found
Error from server (NotFound): error when creating "kubernetes/nginx-ingress-controller.yaml": namespaces "ingress-nginx" not found
```